### PR TITLE
Fix premature wrapping of long Arabic item names in PDFs

### DIFF
--- a/public/doc.js
+++ b/public/doc.js
@@ -109,7 +109,11 @@ async function downloadPdf(id) {
     const itemStartX = (doc.internal.pageSize.getWidth() - tableW) / 2;
 
     function drawItemRow(desc, cost, qty, total) {
-        const descLines = doc.splitTextToSize(desc, colWDesc - horizontalPad * 2);
+        // jsPDF calculates line widths before applying Arabic shaping which can
+        // cause premature wrapping. Process the text first so the split widths
+        // match what will be rendered.
+        const processed = doc.processArabic ? doc.processArabic(desc) : desc;
+        const descLines = doc.splitTextToSize(processed, colWDesc - horizontalPad * 2);
         const lines = Math.max(descLines.length, 1);
         const rowH = lines * lineH + verticalPad * 2;
         doc.rect(itemStartX, y, colWTotal, rowH);
@@ -122,7 +126,9 @@ async function downloadPdf(id) {
         doc.text(cost, itemStartX + colWTotal + colWQty + colWCost - horizontalPad, baseY, { align: 'right', baseline: 'middle' });
         descLines.forEach((ln, idx) => {
             const lineY = y + rowH / 2 + (idx - (descLines.length - 1) / 2) * lineH;
-            doc.text(ln, itemStartX + colWTotal + colWQty + colWCost + colWDesc - horizontalPad, lineY, { align: 'right', baseline: 'middle' });
+            // Pass `true` as isInputVisual so jsPDF doesn't reprocess the text
+            // and potentially change its width again.
+            doc.text(ln, itemStartX + colWTotal + colWQty + colWCost + colWDesc - horizontalPad, lineY, { align: 'right', baseline: 'middle' }, 0, 0, true);
         });
         y += rowH;
     }

--- a/public/report.js
+++ b/public/report.js
@@ -445,7 +445,10 @@ async function downloadPdf(id) {
     const itemStartX = (doc.internal.pageSize.getWidth() - tableW) / 2;
 
     function drawItemRow(desc, cost, qty, total) {
-        const descLines = doc.splitTextToSize(desc, colWDesc - horizontalPad * 2);
+        // Preprocess the text to account for Arabic shaping so that
+        // splitTextToSize measures the same width that will be rendered.
+        const processed = doc.processArabic ? doc.processArabic(desc) : desc;
+        const descLines = doc.splitTextToSize(processed, colWDesc - horizontalPad * 2);
         const lines = Math.max(descLines.length, 1);
         const rowH = lines * lineH + verticalPad * 2;
         doc.rect(itemStartX, y, colWTotal, rowH);
@@ -458,7 +461,8 @@ async function downloadPdf(id) {
         doc.text(cost, itemStartX + colWTotal + colWQty + colWCost - horizontalPad, baseY, { align: 'right', baseline: 'middle' });
         descLines.forEach((ln, idx) => {
             const lineY = y + rowH / 2 + (idx - (descLines.length - 1) / 2) * lineH;
-            doc.text(ln, itemStartX + colWTotal + colWQty + colWCost + colWDesc - horizontalPad, lineY, { align: 'right', baseline: 'middle' });
+            // Pass isInputVisual=true so jsPDF doesn't modify the shaped text again
+            doc.text(ln, itemStartX + colWTotal + colWQty + colWCost + colWDesc - horizontalPad, lineY, { align: 'right', baseline: 'middle' }, 0, 0, true);
         });
         y += rowH;
     }


### PR DESCRIPTION
## Summary
- Prevent premature line breaks in item descriptions for generated PDFs by pre-processing Arabic text before measuring width
- Apply same fix to the report editor download logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d5eee4bc8325b830d9eed529badb