### PR TITLE
Add report deletion to admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -24,6 +24,20 @@
     </div>
     <button id="saveAccuracyBtn" class="btn btn-secondary mb-3" type="button">حفظ الإعداد</button>
     <div id="accuracyResult" class="mt-2"></div>
+
+    <hr class="my-4">
+    <h2 class="mb-3">التقارير</h2>
+    <table id="reportsTable" class="table table-striped">
+        <thead>
+            <tr>
+                <th>المعرف</th>
+                <th>التاريخ</th>
+                <th>الإجمالي</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/admin.js"></script>

--- a/public/admin.js
+++ b/public/admin.js
@@ -56,8 +56,43 @@ async function saveAccuracy() {
     }
 }
 
+async function loadReports() {
+    try {
+        const res = await fetch('/api/report/all');
+        if (!res.ok) return;
+        const reports = await res.json();
+        const tbody = document.querySelector('#reportsTable tbody');
+        tbody.innerHTML = '';
+        reports.forEach(r => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${r.id}</td>
+                <td>${new Date(r.created_at).toLocaleString()}</td>
+                <td>${r.total.toFixed(2)}</td>
+                <td><button class="btn btn-sm btn-danger delete-btn" data-id="${r.id}">حذف</button></td>
+            `;
+            tbody.appendChild(tr);
+        });
+        tbody.querySelectorAll('button.delete-btn').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                if (!confirm('هل أنت متأكد من الحذف؟')) return;
+                const id = btn.dataset.id;
+                const resp = await fetch(`/api/report/${id}`, { method: 'DELETE' });
+                if (resp.ok) {
+                    btn.closest('tr').remove();
+                } else {
+                    alert('فشل الحذف');
+                }
+            });
+        });
+    } catch (e) {
+        console.warn('failed to load reports');
+    }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
     loadAccuracy();
+    loadReports();
     const btn = document.getElementById('saveAccuracyBtn');
     if (btn) btn.addEventListener('click', saveAccuracy);
 });


### PR DESCRIPTION
## Summary
- Add API endpoint to delete reports and cleanup associated data
- Display all reports on admin page with totals and a delete button
- Load report list and handle deletion via new admin.js logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1de60ff908325821a0f4a3c111dc9