### PR TITLE
Format report dates as DD/MM/YYYY

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -67,7 +67,7 @@ async function loadReports() {
             const tr = document.createElement('tr');
             tr.innerHTML = `
                 <td>${r.id}</td>
-                <td>${new Date(r.created_at).toLocaleString()}</td>
+                <td>${new Date(r.created_at).toLocaleDateString('en-GB')}</td>
                 <td>${r.total.toFixed(2)}</td>
                 <td><button class="btn btn-sm btn-danger delete-btn" data-id="${r.id}">حذف</button></td>
             `;

--- a/public/doc.js
+++ b/public/doc.js
@@ -17,7 +17,7 @@ async function loadReports() {
         tr.innerHTML = `
             <td>${rep.id}</td>
             <td>${rep.total.toFixed(2)}</td>
-            <td>${new Date(rep.created_at).toLocaleString()}</td>
+            <td>${new Date(rep.created_at).toLocaleDateString('en-GB')}</td>
             <td>
                 <button class="btn btn-sm btn-outline-primary download-btn" data-id="${rep.id}">تنزيل PDF</button>
                 <button class="btn btn-sm btn-outline-secondary edit-btn" data-id="${rep.id}"><i class="bi bi-pencil"></i></button>

--- a/public/report.js
+++ b/public/report.js
@@ -171,7 +171,7 @@ async function loadReport() {
         tr.innerHTML = `
             <td>${rep.id}</td>
             <td>${rep.total.toFixed(2)}</td>
-            <td>${new Date(rep.created_at).toLocaleString()}</td>
+            <td>${new Date(rep.created_at).toLocaleDateString('en-GB')}</td>
             <td><button class="btn btn-sm btn-outline-primary" data-id="${rep.id}">تنزيل PDF</button></td>
         `;
         tbody.appendChild(tr);

--- a/public/script.js
+++ b/public/script.js
@@ -31,7 +31,7 @@ async function fetchItems(category = '') {
             <td>${item.description}</td>
             <td>${item.unit}</td>
             <td>${item.cost}</td>
-            <td>${new Date(item.created_at).toLocaleString()}</td>
+            <td>${new Date(item.created_at).toLocaleDateString('en-GB')}</td>
             <td>
                 <button class="btn btn-sm btn-link text-primary edit-btn"><i class="bi bi-pencil"></i></button>
                 <button class="btn btn-sm btn-link text-danger delete-btn"><i class="bi bi-x-lg"></i></button>


### PR DESCRIPTION
## Summary
- display only the date in report listings across admin, documentation, item, and report pages
- format dates as DD/MM/YYYY via `toLocaleDateString('en-GB')`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f2ddeec083258961b308688cac9c