### PR TITLE
Simplify PDF download button label

### DIFF
--- a/public/report.js
+++ b/public/report.js
@@ -173,7 +173,7 @@ async function loadReport() {
             <td>${rep.police_report || ''}</td>
             <td>${rep.total.toFixed(2)}</td>
             <td>${new Date(rep.created_at).toLocaleDateString('en-GB')}</td>
-            <td><button class="btn btn-sm btn-outline-primary" data-id="${rep.id}">تنزيل PDF</button></td>
+            <td><button class="btn btn-sm btn-outline-primary" data-id="${rep.id}">PDF</button></td>
         `;
         tbody.appendChild(tr);
     });


### PR DESCRIPTION
## Summary
- Simplify previous reports' PDF download button label to "PDF"

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f9e5b0248325aff8b767d3cbba94