### PR TITLE
Format report dates as DD/MM/YY

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -68,7 +68,7 @@ async function loadReports() {
             tr.innerHTML = `
                 <td>${r.id}</td>
                 <td>${r.police_report || ''}</td>
-                <td>${new Date(r.created_at).toLocaleDateString('en-GB')}</td>
+                <td>${new Date(r.created_at).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: '2-digit' })}</td>
                 <td>${r.total.toFixed(2)}</td>
                 <td><button class="btn btn-sm btn-danger delete-btn" data-id="${r.id}">حذف</button></td>
             `;

--- a/public/doc.js
+++ b/public/doc.js
@@ -18,7 +18,7 @@ async function loadReports() {
             <td>${rep.id}</td>
             <td>${rep.police_report || ''}</td>
             <td>${rep.total.toFixed(2)}</td>
-            <td>${new Date(rep.created_at).toLocaleDateString('en-GB')}</td>
+            <td>${new Date(rep.created_at).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: '2-digit' })}</td>
             <td>
                 <button class="btn btn-sm btn-outline-primary download-btn" data-id="${rep.id}">تنزيل PDF</button>
                 <button class="btn btn-sm btn-outline-secondary edit-btn" data-id="${rep.id}"><i class="bi bi-pencil"></i></button>

--- a/public/report.js
+++ b/public/report.js
@@ -172,7 +172,7 @@ async function loadReport() {
             <td>${rep.id}</td>
             <td>${rep.police_report || ''}</td>
             <td>${rep.total.toFixed(2)}</td>
-            <td>${new Date(rep.created_at).toLocaleDateString('en-GB')}</td>
+            <td>${new Date(rep.created_at).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: '2-digit' })}</td>
             <td><button class="btn btn-sm btn-outline-primary" data-id="${rep.id}">PDF</button></td>
         `;
         tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- format report list dates with two-digit years for admin view
- show report list dates in DD/MM/YY for document view
- format report list dates in short-year style on report form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a21e0f144c832586032c592d08a8c5